### PR TITLE
[Moogle/issues/#7] CODEOWNERS 파일 생성

### DIFF
--- a/CODEOWNERS.txt
+++ b/CODEOWNERS.txt
@@ -1,0 +1,1 @@
+* @dlwltjd7778 @lahreum @me-hana @meloncha @RGunny @junghyun100


### PR DESCRIPTION
사용시 텍스트 확장자 지우고, .git폴더 내부로 넣어주기