### PR TITLE
[Feature #18] Swagger 설정

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -39,6 +39,10 @@ dependencies {
 	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
 	implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
 
+	// Swagger
+	implementation group: 'io.springfox', name: 'springfox-swagger2', version: '2.9.2'
+	implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.9.2'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/backend/src/main/java/com/progbm/Moogle/config/SwaggerConfig.java
+++ b/backend/src/main/java/com/progbm/Moogle/config/SwaggerConfig.java
@@ -1,0 +1,42 @@
+package com.progbm.Moogle.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+@Configuration
+@EnableSwagger2
+public class SwaggerConfig {
+
+    /**
+     * 스웨거 API 문서 생성
+     */
+    @Bean
+    public Docket swaggerAPI() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .host("ec2-52-78-112-34.ap-northeast-2.compute.amazonaws.com")
+                .apiInfo(this.swaggerInfo())
+                .select()
+                .apis(RequestHandlerSelectors.basePackage("com.progbm.Moogle"))
+                .paths(PathSelectors.any())
+                .build()
+                .useDefaultResponseMessages(true); // 기본으로 세팅되는 200, 401, 403, 404 메시지 표시
+    }
+
+    /**
+     * 스웨거 정보
+     */
+    private ApiInfo swaggerInfo() {
+        return new ApiInfoBuilder()
+                .title("Spring Boot REST API Documentation")
+                .description("<h1>[Pro-GBM#1]Moogle 프로젝트의 REST API문서입니다.</h1>")
+                .version("1.0.0")
+                .build();
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -13,5 +13,8 @@ spring:
       hibernate:
         # show_sql: true
         format_sql: true
+  mvc:
+    pathmatch:
+      matching-strategy: ant_path_matcher
 logging.level:
   org.hibernate.SQL: debug


### PR DESCRIPTION
1. Swagger 의존성 추가
- 2.9.2 

2.. boot 2.6 이상 swagger yml 설정
- Spring boot 2.6버전 이후 spring.mvc.pathmatch.matching-strategy 값이 ant_apth_matcher에서 path_pattern_parser로 변경되어 몇몇 라이브러리(swagger포함)에 오류가 발생
- application.yml 설정 추가

3. SwaggerConfig 추가